### PR TITLE
Rewrite syntax highlighter

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   ],
   "icon": "assets/logo.png",
   "activationEvents": [
-    "onLanguage:reason.module",
-    "onLanguage:reason.module.type"
+    "onLanguage:reason.module.defns",
+    "onLanguage:reason.module.decls"
   ],
   "main": "./out/src/extension",
   "contributes": {
@@ -74,14 +74,14 @@
         "path": "./syntaxes/reason-hover.json"
       },
       {
-        "language": "reason.module",
-        "scopeName": "source.reason.module",
-        "path": "./syntaxes/reason-module.json"
+        "language": "reason.module.defns",
+        "scopeName": "source.reason.module.defns",
+        "path": "./syntaxes/reason-module-defns.json"
       },
       {
-        "language": "reason.module.type",
-        "scopeName": "source.reason.module.type",
-        "path": "./syntaxes/reason-module-type.json"
+        "language": "reason.module.decls",
+        "scopeName": "source.reason.module.decls",
+        "path": "./syntaxes/reason-module-decls.json"
       }
     ],
     "languages": [
@@ -92,7 +92,7 @@
         "id": "reason.hover"
       },
       {
-        "id": "reason.module",
+        "id": "reason.module.defns",
         "aliases": [
           "Reason"
         ],
@@ -102,7 +102,7 @@
         "configuration": "./reason.configuration.json"
       },
       {
-        "id": "reason.module.type",
+        "id": "reason.module.decls",
         "aliases": [
           "Reason"
         ],

--- a/reason.configuration.json
+++ b/reason.configuration.json
@@ -4,7 +4,6 @@
     { "open": "[", "close": "]" },
     { "open": "(", "close": ")" },
     { "open": "\"", "close": "\"", "notIn": [ "string" ] },
-    { "open": "`", "close": "`", "notIn": [ "string", "comment" ] },
     { "open": "/**", "close": " */", "notIn": [ "string" ] }
   ],
   "brackets": [

--- a/src/client.ts
+++ b/src/client.ts
@@ -14,7 +14,7 @@ export function launch(context: vscode.ExtensionContext): vscode.Disposable {
   const debug = { module, transport, options };
 
   const serverOptions = { run, debug };
-  const clientOptions = { documentSelector: [ 'reason.module', 'reason.module.type' ] };
+  const clientOptions = { documentSelector: [ 'reason.module.defns', 'reason.module.decls' ] };
   const reasonClient = new client.LanguageClient('Reason', serverOptions, clientOptions);
 
   reasonClient.onRequest<client.TextDocumentPositionParams, string | undefined, void>({ method: 'getText' }, async (data) => {

--- a/syntaxes/reason-common.json
+++ b/syntaxes/reason-common.json
@@ -260,7 +260,7 @@
       ]
     },
     "module-item-let": {
-      "begin": "(?:\\G|^)[[:space:]]*\\b(let)\\b[[:space:]]*(?=[_\\(A-Za-z]|$)",
+      "begin": "(?:\\G|^)[[:space:]]*\\b(let)\\b[[:space:]]*",
       "end": "(;)|(?=[\\}])",
       "beginCaptures": {
         "1": { "name": "storage.type.reason" }
@@ -299,7 +299,7 @@
       ]
     },
     "module-item-let-module-bind-body": {
-      "begin": "(=>?)[[:space:]]*(?=[\\{A-Z]|$)",
+      "begin": "(=>?)[[:space:]]*",
       "end": "(?=\\band\\b|[;\\}])",
       "beginCaptures": {
         "1": { "name": "keyword.operator.reason" }
@@ -319,7 +319,7 @@
       ]
     },
     "module-item-let-module-bind-type": {
-      "begin": "(:)[[:space:]]*(?=[\\{A-Z]|$)",
+      "begin": "(:)[[:space:]]*",
       "end": "(?=\\band\\b|[;\\}=])",
       "beginCaptures": {
         "1": { "name": "keyword.operator.reason" }
@@ -369,7 +369,7 @@
       ]
     },
     "module-item-let-value-bind-body": {
-      "begin": "(=>?)[[:space:]]*(?=[_!'\"\\(\\[\\{`0-9A-Za-z]|$)",
+      "begin": "(=>?)[[:space:]]*",
       "end": "(?=\\band\\b|[;\\)\\}])",
       "beginCaptures": {
         "1": { "name": "keyword.operator.reason" }
@@ -380,7 +380,7 @@
     },
     "module-item-let-value-bind-name-params": {
       "comment": "FIXME: determine why usual anchor doesn't work here",
-      "begin": "(?<=^|[[:space:]])\\b([_a-z][A-Za-z0-9_']*)\\b[[:space:]]*(?=[_:'\"\\(\\[\\{`=0-9A-Za-z]|$)",
+      "begin": "(?<=^|[[:space:]])(?!\\blazy\\b)\\b([_a-z][A-Za-z0-9_']*)\\b[[:space:]]*",
       "end": "(?<!:)(?!::)(?=[:=])",
       "beginCaptures": {
         "1": { "name": "entity.name.function" }
@@ -407,7 +407,7 @@
       ]
     },
     "module-item-let-value-bind-pattern": {
-      "begin": "(?=[A-Z])",
+      "begin": "",
       "end": "(?==)",
       "patterns": [
         { "include": "#pattern" }
@@ -425,7 +425,7 @@
       ]
     },
     "module-item-let-value-bind-name-params-type-body": {
-      "begin": "(?!\\bmodule|rec\\b)(?=[_\\(A-Za-z])",
+      "begin": "(?!\\bmodule|rec\\b)",
       "end": "(?=\\band\\b|[;\\}])",
       "patterns": [
         { "include": "#module-item-let-value-bind-name-params" },

--- a/syntaxes/reason-common.json
+++ b/syntaxes/reason-common.json
@@ -1,21 +1,158 @@
 {
   "scopeName": "source.reason.common",
   "repository": {
-    "bind-item-module": {
+    "attribute": {
+      "begin": "(?=\\[(@{1,3})[[:space:]]*[A-Za-z])",
+      "end": "\\]",
       "patterns": [
-        { "include": "#item-let-module-defn-0" },
-        { "include": "#item-let-module-defn-1" },
-        { "include": "#item-let-module-defn-2" },
-        { "include": "#item-let-module-defn-3" },
-        { "include": "#comment" }
+        {
+          "begin": "\\[(@{1,3})[[:space:]]*",
+          "end": "(?=[[:space:]:?])",
+          "beginCaptures": {
+            "1": { "name": "keyword.other" }
+          },
+          "patterns": [
+            { "include": "#attribute-identifier" }
+          ]
+        },
+        {
+          "begin": "[[:space:]]+",
+          "end": "(?=\\])",
+          "patterns": [
+            {
+              "comment": "FIXME: should be module-items",
+              "include": "#value-expression"
+            }
+          ]
+        },
+        {
+          "begin": "(:)",
+          "end": "(?=\\])",
+          "beginCaptures": {
+            "1": { "name": "keyword.operator" }
+          },
+          "patterns": [
+            { "include": "#type-expression" }
+          ]
+        }
       ]
     },
-    "bind-item-type": {
+    "attribute-identifier": {
       "patterns": [
-        { "include": "#item-type-defn-0" },
-        { "include": "#item-type-defn-1" },
-        { "include": "#item-type-defn-2" },
-        { "include": "#comment" }
+        {
+          "match": "\\b([A-Za-z][A-Za-z0-9_']*)\\b[[:space:]]*(?:(\\.)|(?=;))",
+          "captures": {
+            "1": { "name": "entity.name.class" },
+            "2": { "name": "keyword.operator" }
+          }
+        },
+        {
+          "name": "constant.language",
+          "match": "[A-Za-z][_\\'0-9A-Za-z]*"
+        }
+      ]
+    },
+    "class-item-method": {
+      "begin": "\\b(method)\\b[[:space:]]*",
+      "end": "(;)|(?=[\\}])",
+      "beginCaptures": {
+        "1": { "name": "storage.type.reason" }
+      },
+      "endCaptures": {
+        "1": { "name": "keyword.operator" }
+      },
+      "patterns": [
+        { "include": "#class-item-method-bind-name-params-body" }
+      ]
+    },
+    "class-item-method-bind-body": {
+      "begin": "(=>?)",
+      "end": "(?=\\band\\b|[;\\}])",
+      "beginCaptures": {
+        "1": { "name": "keyword.operator.reason" }
+      },
+      "patterns": [
+        { "include": "#value-expression" }
+      ]
+    },
+    "class-item-method-bind-name-params": {
+      "begin": "\\b([_a-z][A-Za-z0-9_']*)\\b[[:space:]]*",
+      "end": "(?==)",
+      "beginCaptures": {
+        "1": { "name": "entity.name.function" }
+      },
+      "patterns": [
+        { "include": "#class-item-method-param" }
+      ]
+    },
+    "class-item-method-bind-parens-params": {
+      "begin": "(?:\\G|^)[[:space:]]*(?=\\()",
+      "end": "(?==)",
+      "patterns": [
+        {
+          "begin": "\\G\\([[:space:]]*",
+          "end": "[[:space:]]*\\)[[:space:]]*",
+          "patterns": [
+            { "include": "#operator-infix-custom" }
+          ]
+        },
+        { "include": "#class-item-method-param" }
+      ]
+    },
+    "class-item-method-bind-name-params-body": {
+      "begin": "(?=(\\G|^)[[:space:]]*)",
+      "end": "(?=\\band\\b|[;\\}])",
+      "patterns": [
+        { "include": "#class-item-method-bind-name-params" },
+        { "include": "#class-item-method-bind-parens-params" },
+        { "include": "#class-item-method-bind-body" }
+      ]
+    },
+    "class-item-method-param": {
+      "patterns": [
+        { "include": "#class-item-method-param-type" },
+        { "include": "#class-item-method-param-module" },
+        { "include": "#pattern" }
+      ]
+    },
+    "class-item-method-param-type": {
+      "comment": "FIXME: merge with pattern-parens",
+      "begin": "[[:space:]]*\\([[:space:]]*(?=\\btype\\b)",
+      "end": "[[:space:]]*\\)[[:space:]]*",
+      "patterns": [
+        {
+          "begin": "[[:space:]]*\\b(type)\\b[[:space:]]*",
+          "end": "(?=\\))",
+          "beginCaptures": {
+            "1": { "name": "keyword.other" }
+          },
+          "patterns": [
+            {
+              "name": "support.type",
+              "match": "(?:\\G|^)[[:space:]]*\\b[a-z][A-Za-z0-9_']*\\b"
+            }
+          ]
+        }
+      ]
+    },
+    "class-item-method-param-module": {
+      "comment": "FIXME: merge with pattern-parens",
+      "begin": "[[:space:]]*\\([[:space:]]*(?=\\bmodule\\b)",
+      "end": "[[:space:]]*\\)[[:space:]]*",
+      "patterns": [
+        {
+          "begin": "[[:space:]]*\\b(module)\\b[[:space:]]*",
+          "end": "(?=\\))",
+          "beginCaptures": {
+            "1": { "name": "keyword.other" }
+          },
+          "patterns": [
+            {
+              "name": "entity.name.class",
+              "match": "(?:\\G|^)[[:space:]]*\\b[A-Z][A-Za-z0-9_']*\\b"
+            }
+          ]
+        }
       ]
     },
     "comment": {
@@ -27,389 +164,1263 @@
           "captures": {
             "1": { "name": "comment.block.reason" },
             "2": { "name": "punctuation.definition.comment.reason" }
+          },
+          "patterns": [
+            { "include": "#comment" }
+          ]
+        }
+      ]
+    },
+    "extension-node": {
+      "begin": "(?=\\[(%{1,3})[[:space:]]*[A-Za-z])",
+      "end": "\\]",
+      "patterns": [
+        {
+          "begin": "\\[(%{1,3})[[:space:]]*",
+          "end": "(?=[[:space:]:?])",
+          "beginCaptures": {
+            "1": { "name": "keyword.other" }
+          },
+          "patterns": [
+            { "include": "#attribute-identifier" }
+          ]
+        },
+        {
+          "begin": "(:)",
+          "end": "(?=\\])",
+          "beginCaptures": {
+            "1": { "name": "keyword.operator" }
+          },
+          "patterns": [
+            { "include": "#type-expression" }
+          ]
+        }
+      ]
+    },
+    "module-expression": {
+      "patterns": [
+        {
+          "patterns": [
+            { "include": "#module-expression-path" },
+            {
+              "match": "\\b([A-Z][A-Za-z0-9_']*)\\b[[:space:]]*",
+              "captures": {
+                "1": { "name": "name.entity.class" }
+              }
+            }
+          ]
+        },
+        { "include": "#module-expression-block" }
+      ]
+    },
+    "module-expression-block": {
+      "begin": "\\{[[:space:]]*",
+      "end": "\\}",
+      "patterns": [
+        { "include": "#module-expression-block-item" }
+      ]
+    },
+    "module-expression-block-item": {
+      "begin": "(?:\\G|^|(;))[[:space:]]*",
+      "end": "[[:space:]]*(?=[;\\}])",
+      "beginCaptures": {
+        "1": { "name": "keyword.operator" }
+      },
+      "endCaptures": {
+        "1": { "name": "keyword.operator" }
+      },
+      "patterns": [
+        { "include": "#attribute" },
+        { "include": "#comment" },
+        { "include": "#module-item-include" },
+        { "include": "#module-item-let" },
+        { "include": "#module-item-module-type" },
+        { "include": "#module-item-open" },
+        { "include": "#module-item-type" }
+      ]
+    },
+    "module-expression-path": {
+      "match": "\\b([A-Z][A-Za-z0-9_']*)\\b[[:space:]]*(?:(\\.)|(?=;))",
+      "captures": {
+        "1": { "name": "entity.name.class" },
+        "2": { "name": "keyword.operator" }
+      }
+    },
+    "module-item-include": {
+      "begin": "\\b(include)\\b[[:space:]]*",
+      "end": "(;)",
+      "beginCaptures": {
+        "1": { "name": "keyword.other" }
+      },
+      "endCaptures": {
+        "1": { "name": "keyword.other" }
+      },
+      "patterns": [
+        { "include": "#module-expression-path" }
+      ]
+    },
+    "module-item-let": {
+      "begin": "(?:\\G|^)[[:space:]]*\\b(let)\\b[[:space:]]*(?=[_\\(A-Za-z]|$)",
+      "end": "(;)|(?=[\\}])",
+      "beginCaptures": {
+        "1": { "name": "storage.type.reason" }
+      },
+      "endCaptures": {
+        "1": { "name": "keyword.operator" }
+      },
+      "patterns": [
+        { "include": "#module-item-let-module" },
+        { "include": "#module-item-let-value" }
+      ]
+    },
+    "module-item-let-module": {
+      "begin": "(?:\\G|^)[[:space:]]*\\b(module)\\b[[:space:]]*(?=\\b(rec|type)\\b|[A-Z]|$)",
+      "end": "(?=[;\\}])",
+      "beginCaptures": {
+        "1": { "name": "storage.type.reason" }
+      },
+      "endCaptures": {
+        "1": { "name": "keyword.operator" }
+      },
+      "patterns": [
+        { "include": "#module-item-let-module-and" },
+        { "include": "#module-item-let-module-rec" },
+        { "include": "#module-item-let-module-bind-name-params-type-body" }
+      ]
+    },
+    "module-item-let-module-and": {
+      "begin": "\\b(and)\\b[[:space:]]*",
+      "end": "(?=\\band\\b|[;\\}])",
+      "beginCaptures": {
+        "1": { "name": "storage.type.reason" }
+      },
+      "patterns": [
+        { "include": "#module-item-let-module-bind-name-params-type-body" }
+      ]
+    },
+    "module-item-let-module-bind-body": {
+      "begin": "(=>?)[[:space:]]*(?=[\\{A-Z]|$)",
+      "end": "(?=\\band\\b|[;\\}])",
+      "beginCaptures": {
+        "1": { "name": "keyword.operator.reason" }
+      },
+      "patterns": [
+        { "include": "#module-expression" }
+      ]
+    },
+    "module-item-let-module-bind-name-params": {
+      "begin": "\\b([A-Z][A-Za-z0-9_']*)\\b[[:space:]]*(?=[\\(|:=]|$)",
+      "end": "(?=[:=])",
+      "beginCaptures": {
+        "1": { "name": "entity.name.class" }
+      },
+      "patterns": [
+        { "include": "#module-item-let-module-param" }
+      ]
+    },
+    "module-item-let-module-bind-type": {
+      "begin": "(:)[[:space:]]*(?=[\\{A-Z]|$)",
+      "end": "(?=\\band\\b|[;\\}=])",
+      "beginCaptures": {
+        "1": { "name": "keyword.operator.reason" }
+      },
+      "patterns": [
+        { "include": "#module-expression" }
+      ]
+    },
+    "module-item-let-module-bind-name-params-type-body": {
+      "begin": "(?:\\G|^)[[:space:]]*(?=[A-Z])",
+      "end": "(?=\\band\\b|[;\\}])",
+      "patterns": [
+        { "include": "#module-item-let-module-bind-name-params" },
+        { "include": "#module-item-let-module-bind-type" },
+        { "include": "#module-item-let-module-bind-body" }
+      ]
+    },
+    "module-item-let-module-param": {
+      "patterns": [
+      ]
+    },
+    "module-item-let-module-rec": {
+      "begin": "(?:\\G|^)[[:space:]]*\\b(rec)\\b[[:space:]]*(?=[A-Z]|$)",
+      "end": "(?=\\band\\b|[;\\}])",
+      "beginCaptures": {
+        "1": { "name": "storage.modifier.rec.reason" }
+      },
+      "patterns": [
+        { "include": "#module-item-let-module-bind-name-params-type-body" }
+      ]
+    },
+    "module-item-let-value": {
+      "patterns": [
+        { "include": "#module-item-let-value-and" },
+        { "include": "#module-item-let-value-rec" },
+        { "include": "#module-item-let-value-bind-name-params-type-body" }
+      ]
+    },
+    "module-item-let-value-and": {
+      "begin": "\\b(and)\\b[[:space:]]*",
+      "end": "(?=\\band\\b|[;\\}])",
+      "beginCaptures": {
+        "1": { "name": "storage.type.reason" }
+      },
+      "patterns": [
+        { "include": "#module-item-let-value-bind-name-params-type-body" }
+      ]
+    },
+    "module-item-let-value-bind-body": {
+      "begin": "(=>?)[[:space:]]*(?=[_!'\"\\(\\[\\{`0-9A-Za-z]|$)",
+      "end": "(?=\\band\\b|[;\\)\\}])",
+      "beginCaptures": {
+        "1": { "name": "keyword.operator.reason" }
+      },
+      "patterns": [
+        { "include": "#value-expression" }
+      ]
+    },
+    "module-item-let-value-bind-name-params": {
+      "comment": "FIXME: determine why usual anchor doesn't work here",
+      "begin": "(?<=^|[[:space:]])\\b([_a-z][A-Za-z0-9_']*)\\b[[:space:]]*(?=[_:'\"\\(\\[\\{`=0-9A-Za-z]|$)",
+      "end": "(?<!:)(?!::)(?=[:=])",
+      "beginCaptures": {
+        "1": { "name": "entity.name.function" }
+      },
+      "patterns": [
+        { "include": "#module-item-let-value-param" }
+      ]
+    },
+    "module-item-let-value-bind-parens-params": {
+      "begin": "(?=\\()",
+      "end": "(?!::)(?=[:=])",
+      "patterns": [
+        {
+          "begin": "\\G\\([[:space:]]*",
+          "end": "[[:space:]]*\\)[[:space:]]*",
+          "patterns": [
+            { "include": "#operator-infix-custom" },
+            { "include": "#pattern" },
+            { "include": "#pattern-parens-lhs" },
+            { "include": "#pattern-parens-rhs" }
+          ]
+        },
+        { "include": "#module-item-let-value-param" }
+      ]
+    },
+    "module-item-let-value-bind-pattern": {
+      "begin": "(?=[A-Z])",
+      "end": "(?==)",
+      "patterns": [
+        { "include": "#pattern" }
+      ]
+    },
+    "module-item-let-value-bind-type": {
+      "comment": "FIXME: lookahead",
+      "begin": "(:)[[:space:]]*",
+      "end": "(?=\\band\\b|[;\\}]|=(?!>))",
+      "beginCaptures": {
+        "1": { "name": "keyword.operator.reason" }
+      },
+      "patterns": [
+        { "include": "#type-expression" }
+      ]
+    },
+    "module-item-let-value-bind-name-params-type-body": {
+      "begin": "(?!\\bmodule|rec\\b)(?=[_\\(A-Za-z])",
+      "end": "(?=\\band\\b|[;\\}])",
+      "patterns": [
+        { "include": "#module-item-let-value-bind-name-params" },
+        { "include": "#module-item-let-value-bind-parens-params" },
+        { "include": "#module-item-let-value-bind-pattern" },
+        { "include": "#module-item-let-value-bind-type" },
+        { "include": "#module-item-let-value-bind-body" }
+      ]
+    },
+    "module-item-let-value-param": {
+      "patterns": [
+        { "include": "#module-item-let-value-param-label" },
+        { "include": "#module-item-let-value-param-type" },
+        { "include": "#module-item-let-value-param-module" },
+        { "include": "#pattern" }
+      ]
+    },
+    "module-item-let-value-param-label": {
+      "patterns": [
+        {
+          "begin": "[[:space:]]*\\b([_a-z][_'A-Za-z0-9]*)\\b(::)",
+          "end": "(?<=[[:space:]])",
+          "beginCaptures": {
+            "1": { "name": "constant.language" },
+            "2": { "name": "keyword.other" }
+          },
+          "patterns": [
+            { "include": "#pattern" },
+            {
+              "begin": "(=)",
+              "end": "(\\?)|(?=[[:space:]])",
+              "beginCaptures": {
+                "1": { "name": "keyword.other" }
+              },
+              "endCaptures": {
+                "1": { "name": "storage.type" }
+              },
+              "patterns": [
+                { "include": "#value-expression" }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "module-item-let-value-param-module": {
+      "comment": "FIXME: merge with pattern-parens",
+      "begin": "[[:space:]]*\\([[:space:]]*(?=\\bmodule\\b)",
+      "end": "[[:space:]]*\\)[[:space:]]*",
+      "patterns": [
+        {
+          "begin": "[[:space:]]*\\b(module)\\b[[:space:]]*",
+          "end": "(?=\\))",
+          "beginCaptures": {
+            "1": { "name": "keyword.other" }
+          },
+          "patterns": [
+            {
+              "name": "entity.name.class",
+              "match": "(?:\\G|^)[[:space:]]*\\b[A-Z][A-Za-z0-9_']*\\b"
+            }
+          ]
+        }
+      ]
+    },
+    "module-item-let-value-param-type": {
+      "comment": "FIXME: merge with pattern-parens",
+      "begin": "[[:space:]]*\\([[:space:]]*(?=\\btype\\b)",
+      "end": "[[:space:]]*\\)[[:space:]]*",
+      "patterns": [
+        {
+          "begin": "[[:space:]]*\\b(type)\\b[[:space:]]*",
+          "end": "(?=\\))",
+          "beginCaptures": {
+            "1": { "name": "keyword.other" }
+          },
+          "patterns": [
+            {
+              "name": "support.type",
+              "match": "(?:\\G|^)[[:space:]]*\\b[a-z][A-Za-z0-9_']*\\b"
+            }
+          ]
+        }
+      ]
+    },
+    "module-item-let-value-rec": {
+      "begin": "\\b(rec)\\b[[:space:]]*",
+      "end": "(?=\\band\\b|[;\\}])",
+      "beginCaptures": {
+        "1": { "name": "storage.modifier.rec.reason" }
+      },
+      "patterns": [
+        { "include": "#module-item-let-value-bind-name-params-type-body" }
+      ]
+    },
+    "module-item-module-type": {
+      "begin": "(?:\\G|^)[[:space:]]*\\b(module)\\b[[:space:]]*(?=\\btype\\b|$)",
+      "end": "(;)",
+      "beginCaptures": {
+        "1": { "name": "storage.type.reason" }
+      },
+      "endCaptures": {
+        "1": { "name": "keyword.other" }
+      },
+      "patterns": [
+        {
+          "begin": "(?:\\G|^)[[:space:]]*\\b(type)\\b[[:space:]]*(?=[A-Z])",
+          "end": "(?==)",
+          "beginCaptures": {
+            "1": { "name": "keyword.other" }
+          },
+          "patterns": [
+            {
+              "match": "([A-Z][_'0-9A-Za-z]*)[[:space:]]*(?==|$)",
+              "captures": {
+                "1": { "name": "entity.name.class" }
+              }
+            }
+          ]
+        },
+        {
+          "begin": "(=)[[:space:]]*(?=\\{|$)",
+          "end": "(?=;)",
+          "beginCaptures": {
+            "1": { "name": "keyword.other" }
+          },
+          "patterns": [
+            { "include": "#module-expression" }
+          ]
+        }
+      ]
+    },
+    "module-item-open": {
+      "begin": "\\b(open)\\b[[:space:]]*",
+      "end": "(;)",
+      "beginCaptures": {
+        "1": { "name": "keyword.other" }
+      },
+      "endCaptures": {
+        "1": { "name": "keyword.other" }
+      },
+      "patterns": [
+        { "include": "#module-expression-path" }
+      ]
+    },
+    "module-item-type": {
+      "begin": "\\b(type)\\b[[:space:]]*",
+      "end": "(;)",
+      "beginCaptures": {
+        "1": { "name": "keyword.other" }
+      },
+      "endCaptures": {
+        "1": { "name": "keyword.operator" }
+      },
+      "patterns": [
+        { "include": "#module-item-type-and" },
+        { "include": "#module-item-type-bind" }
+      ]
+    },
+    "module-item-type-and": {
+      "begin": "(?:\\G|^)[[:space:]]*\\b(and)\\b[[:space:]]*",
+      "end": "(?=\\band\\b|;)",
+      "beginCaptures": {
+        "1": { "name": "keyword.other" }
+      },
+      "patterns": [
+        { "include": "#module-item-type-bind-name-tyvars-body" }
+      ]
+    },
+    "module-item-type-bind": {
+      "patterns": [
+        { "include": "#module-item-type-bind-nonrec" },
+        { "include": "#module-item-type-bind-name-tyvars-body" }
+      ]
+    },
+    "module-item-type-bind-body": {
+      "comment": "FIXME: parsing",
+      "begin": "(=?)",
+      "end": "(?=\\band\\b|;)",
+      "beginCaptures": {
+        "1": { "name": "keyword.operator.reason" }
+      },
+      "patterns": [
+        {
+          "comment": "FIXME: add separate rule; parsing",
+          "match": "(?:\\G|^)[[:space:]]*\\b(private)\\b",
+          "captures": {
+            "1": { "name": "keyword.other" }
+          }
+        },
+        { "include": "#type-expression" },
+        {
+          "match": "\\|",
+          "name": "keyword.operator"
+        },
+        { "include": "#value-expression-literal-constructor-variant" }
+      ]
+    },
+    "module-item-type-bind-nonrec": {
+      "begin": "(?:\\G|^)[[:space:]]*\\b(nonrec)\\b[[:space:]]*",
+      "end": "(?=\\band\\b|;)",
+      "beginCaptures": {
+        "1": { "name": "storage.modifier.nonrec.reason" }
+      },
+      "patterns": [
+        { "include": "#module-item-type-bind-name-tyvars-body" }
+      ]
+    },
+    "module-item-type-bind-name-tyvars": {
+      "begin": "(?:\\G|^)[[:space:]]*\\b([_a-z][A-Za-z0-9_']*)\\b[[:space:]]*",
+      "end": "(?=[;=])",
+      "beginCaptures": {
+        "1": { "name": "entity.name.function" }
+      },
+      "patterns": [
+        { "include": "#comment" },
+        { "include": "#attribute" },
+        {
+          "comment": "FIXME: add separate type-variable rule",
+          "match": "([+\\-])?'([_a-z][A-Za-z0-9_']*)\\b(?!\\.[A-Z])",
+          "captures": {
+            "1": { "name": "keyword.other" },
+            "2": { "name": "variable.parameter" }
           }
         }
       ]
     },
-    "identifier-constructor": {
-      "comment": "FIXME",
-      "name": "constant.language.constructor.reason",
-      "match": "\\b([A-Z]+[[:word:]]*)\\b(?![[:space:]]*\\.)"
+    "module-item-type-bind-name-tyvars-body": {
+      "begin": "(?=(\\G|^)[[:space:]]*\\b[_a-z])",
+      "end": "(?=\\band\\b|;)",
+      "patterns": [
+        { "include": "#module-item-type-bind-name-tyvars" },
+        { "include": "#module-item-type-bind-body" }
+      ]
     },
-    "identifier-module": {
-      "name": "entity.name.class.reason",
-      "match": "\\b([A-Z]+[[:word:]]*)\\b"
+    "pattern": {
+      "patterns": [
+        { "include": "#comment" },
+        { "include": "#module-expression-path" },
+        {
+          "comment": "FIXME",
+          "match": "\\b(lazy)\\b",
+          "captures": {
+            "1": { "name": "keyword.other" }
+          }
+        },
+        { "include": "#pattern-parens" },
+        { "include": "#pattern-atomic" }
+      ]
     },
-    "identifier-type": {
-      "name": "support.type.reason",
-      "match": "(?<!')\\b([a-z][[:word:]]*)\\b"
+    "pattern-atomic": {
+      "patterns": [
+        { "include": "#value-expression-literal" },
+        { "include": "#pattern-list" },
+        { "include": "#pattern-record" },
+        { "include": "#pattern-variable" }
+      ]
     },
-    "identifier-type-variable": {
-      "match": "(')\\b([a-z][[:word:]]*)\\b",
-      "captures": {
-        "2": { "name": "variable.parameter.type.reason" }
-      }
-    },
-    "item-include": {
-      "begin": "\\b(include)\\b",
-      "end": ";",
+    "pattern-guard": {
+      "begin": "\\b(when)\\b",
+      "end": "(?==>)",
       "beginCaptures": {
-        "1": { "name": "keyword.control.import.include.reason" }
+        "1": { "name": "keyword.other" }
+      },
+      "patterns": [
+        { "include": "#value-expression" }
+      ]
+    },
+    "pattern-list": {
+      "begin": "(\\[)(?![@%])",
+      "end": "(\\])",
+      "beginCaptures": {
+        "1": { "name": "constant.language.list.reason" }
       },
       "endCaptures": {
-        "0": { "name": "keyword.operator.reason" }
-      }
-    },
-    "item-let-decl": {
-      "comment": "FIXME: anchors",
-      "begin": "\\b(let)\\b",
-      "end": ";",
-      "beginCaptures": {
-        "1": { "name": "storage.type.let.reason" }
-      },
-      "endCaptures": {
-        "0": { "name": "keyword.operator.reason" }
+        "1": { "name": "constant.language.list.reason" }
       },
       "patterns": [
-        { "include": "#item-let-decl-0" },
-        { "include": "#item-let-decl-1" },
-        { "include": "#comment" }
+        { "include": "#value-expression-literal-list-seperator" },
+        { "include": "#pattern" }
       ]
     },
-    "item-let-decl-0": {
-      "begin": "(?<=let)[[:space:]]+(?!\\bmodule\\b)\\b([a-z][[:word:]]*)\\b",
-      "end": "(?=:)",
+    "pattern-parens": {
+      "begin": "(?=[[:space:]]*\\([[:space:]]*)",
+      "end": "[[:space:]]*\\)[[:space:]]*",
+      "patterns": [
+        { "include": "#pattern-parens-lhs" },
+        { "include": "#pattern-parens-rhs" }
+      ]
+    },
+    "pattern-parens-lhs": {
+      "begin": "[[:space:]]*(?:\\(|(,))[[:space:]]*",
+      "end": "(?=[[:space:]]*(?:[,:\\)]|\\bas\\b)[[:space:]]*)",
       "beginCaptures": {
-        "1": { "name": "entity.name.function.reason" }
+        "1": { "name": "keyword.operator" }
       },
       "patterns": [
-        { "include": "#comment" }
+        { "include": "#pattern" }
       ]
     },
-    "item-let-decl-1": {
-      "begin": ":",
-      "end": "(?=;)",
+    "pattern-parens-rhs": {
+      "patterns": [
+        { "include": "#pattern-parens-rhs-alias" },
+        { "include": "#pattern-parens-rhs-type" }
+      ]
+    },
+    "pattern-parens-rhs-alias": {
+      "begin": "[[:space:]]*\\b(as)\\b[[:space:]]*",
+      "end": "(?=[[:space:]]*[,\\)][[:space:]]*)",
       "beginCaptures": {
-        "0": { "name": "keyword.operator.reason" }
+        "1": { "name": "keyword.other" }
       },
       "patterns": [
-        { "include": "#identifier-type" },
-        { "include": "#identifier-type-variable" },
-        {
-          "name": "keyword.operator.reason",
-          "match": "=>"
-        },
-        { "include": "#comment" }
+        { "include": "#pattern-variable" }
       ]
     },
-    "item-let-defn": {
-      "begin": "\\b(let)\\b",
-      "end": ";",
+    "pattern-parens-rhs-type": {
+      "begin": "[[:space:]]*(:)[[:space:]]*",
+      "end": "(?=[[:space:]]*\\)[[:space:]]*)",
       "beginCaptures": {
-        "1": { "name": "storage.type.let.reason" }
-      },
-      "endCaptures": {
-        "0": { "name": "keyword.operator.reason" }
+        "1": { "name": "keyword.operator" }
       },
       "patterns": [
-        { "include": "#item-let-module-defn" },
-        { "include": "#item-let-rec-val-defn" },
-        { "include": "#item-let-val-defn" },
-        { "include": "#comment" }
+        { "include": "#type-expression" }
       ]
     },
-    "item-let-module-defn": {
-      "begin": "\\b(module)\\b",
-      "end": "(?=;)",
-      "beginCaptures": {
-        "1": { "name": "storage.type.module.reason" }
-      },
+    "pattern-record": {
+      "begin": "[[:space:]]*\\{[[:space:]]*",
+      "end": "[[:space:]]*\\}[[:space:]]*",
       "patterns": [
-        { "include": "#bind-item-module" }
+        { "include": "#pattern-record-item" }
       ]
     },
-    "item-let-module-defn-0": {
-      "name": "storage.modifier.reason",
-      "match": "\\b(and|rec)\\b"
-    },
-    "item-let-module-defn-1": {
-      "begin": "\\b([A-Z]+[[:word:]]*)\\b",
-      "end": "(?=:|=)",
+    "pattern-record-field": {
+      "begin": "[[:space:]]*\\b([_a-z][A-Za-z0-9_']*)[[:space:]]*",
+      "end": "[[:space:]]*(?:(,)|(?=\\}))",
       "beginCaptures": {
-        "1": { "name": "entity.name.class.module.reason" }
-      },
-      "patterns": [
-        { "include": "#comment" }
-      ]
-    },
-    "item-let-module-defn-2": {
-      "begin": ":",
-      "end": "(?==)",
-      "beginCaptures": {
-        "0": { "name": "keyword.operator.reason" }
-      },
-      "patterns": [
-        {
-          "begin": "{",
-          "end": "}",
-          "beginCaptures": {
-            "0": { "name": "meta.brace.curly.reason" }
-          },
-          "endCaptures": {
-            "0": { "name": "meta.brace.curly.reason" }
-          },
-          "patterns": [
-            { "include": "#module-type-items" }
-          ]
-        },
-        { "include": "#comment" }
-      ]
-    },
-    "item-let-module-defn-3": {
-      "begin": "=",
-      "end": "(?=\\b(and)\\b|;)",
-      "beginCaptures": {
-        "0": { "name": "keyword.operator.reason" }
-      },
-      "patterns": [
-        {
-          "begin": "{",
-          "end": "}",
-          "beginCaptures": {
-            "0": { "name": "meta.brace.curly.reason" }
-          },
-          "endCaptures": {
-            "0": { "name": "meta.brace.curly.reason" }
-          },
-          "patterns": [
-            { "include": "source.reason.common#module-items" }
-          ]
-        }
-      ]
-    },
-    "item-let-val-defn": {
-      "comment": "FIXME: anchors",
-      "patterns": [
-        {
-          "name": "storage.modifier.rec.reason",
-          "match": "\\b(rec)\\b"
-        },
-        { "include": "#item-let-val-defn-0" },
-        { "include": "#item-let-val-defn-1" },
-        { "include": "#item-let-val-defn-2" },
-        { "include": "#item-let-val-defn-3" }
-      ]
-    },
-    "item-let-val-defn-0": {
-      "begin": "(?<=rec)[[:space:]]+(?!\\bmodule\\b)\\b([a-z][[:word:]]*)\\b",
-      "end": "(?=[a-z_]|\\(|=|=>)",
-      "beginCaptures": {
-        "1": { "name": "entity.name.function.reason" }
-      },
-      "patterns": [
-        { "include": "#comment" }
-      ]
-    },
-    "item-let-val-defn-1": {
-      "comment": "FIXME",
-      "begin": "(?<=let)[[:space:]]+(?!\\bmodule|rec\\b)\\b([a-z][[:word:]]*)\\b",
-      "end": "(?==)",
-      "beginCaptures": {
-        "1": { "name": "entity.name.function.reason" }
-      },
-      "patterns": [
-        { "include": "#identifier-module" },
-        { "include": "#item-let-val-defn-2" },
-        { "include": "#comment" }
-      ]
-    },
-    "item-let-val-defn-2": {
-      "begin": "\\b([a-z_][[:word:]]*)\\b",
-      "end": "(?=[a-z_]|\\(|{|,|}|\\)|=|=>)",
-      "beginCaptures": {
-        "1": { "name": "variable.parameter.function.reason" }
-      },
-      "patterns": [
-        { "include": "#comment" }
-      ]
-    },
-    "item-let-val-defn-3": {
-      "comment": "FIXME",
-      "begin": "=>?",
-      "end": "(?=;)",
-      "beginCaptures": {
-       "0": { "name": "keyword.operator.reason" }
-      },
-      "patterns": [
-        { "include": "#literal" },
-        { "include": "#module-items" },
-        { "include": "#identifier-constructor" },
-        { "include": "#identifier-module" },
-        {
-          "name": "storage.type.let.reason",
-          "match": "\\b(let)\\b"
-        },
-        {
-          "name": "keyword.control.reason",
-          "match": "\\b(else|downto|for|fun|if|in|not|ref|switch|then|to|when|warning|while)\\b|-|,|::?|:=|\\.\\.\\.|@@|@|/|\\|\\*|\\^|\\+|\\||&&|##?|%|<=?|=>?|>=?"
-        }
-      ]
-    },
-    "item-module-type-defn": {
-      "begin": "\\b(module)\\b",
-      "end": ";",
-      "beginCaptures": {
-        "1": { "name": "storage.type.module.reason" }
+        "1": { "name": "constant.language.field.reason" }
       },
       "endCaptures": {
         "1": { "name": "keyword.operator.reason" }
       },
       "patterns": [
-        { "include": "#item-module-type-defn-0" },
-        { "include": "#item-module-type-defn-1" }
-      ]
-    },
-    "item-module-type-defn-0": {
-      "begin": "\\b(type)\\b",
-      "end": "(?==)",
-      "beginCaptures": {
-        "1": { "name": "keyword.other.type.reason" }
-      },
-      "patterns": [
-        { "include": "#identifier-module" }
-      ]
-    },
-    "item-module-type-defn-1": {
-      "begin": "=",
-      "end": "(?=;)",
-      "patterns": [
         {
-          "begin": "{",
-          "end": "}",
+          "begin": "\\G(:)",
+          "end": "(?=[,\\}])",
+          "beginCaptures": {
+            "1": { "name": "keyword.operator.reason" }
+          },
           "patterns": [
-            { "include": "#module-type-items" }
+            { "include": "#pattern" }
           ]
         }
       ]
     },
-    "item-open": {
-      "begin": "\\b(open)\\b",
-      "end": ";",
-      "beginCaptures": {
-        "0": { "name": "keyword.control.import.include.reason" }
-      },
-      "endCaptures": {
-        "0": { "name": "keyword.operator.reason" }
-      },
+    "pattern-record-item": {
       "patterns": [
-        { "include": "#identifier-module" }
+        { "include": "#module-expression-path" },
+        { "include": "#pattern-record-field" }
       ]
     },
-    "item-type-defn": {
-      "name": "meta.type.reason",
-      "begin": "\\b(type)\\b",
-      "end": ";",
-      "beginCaptures": {
-        "1": { "name": "keyword.other.type.reason" }
-      },
-      "endCaptures": {
-        "0": { "name": "keyword.operator.reason" }
-      },
-      "patterns": [
-        { "include": "#bind-item-type" }
-      ]
-    },
-    "item-type-defn-0": {
-      "match": "\\b(and)|(nonrec)\\b",
+    "pattern-variable": {
+      "match": "\\b([_a-z][A-Za-z0-9_']*)\\b(?!\\.[A-Z])",
       "captures": {
-        "1": { "name": "keyword.other.type.reason" },
-        "2": { "name": "storage.modifier.nonrec.reason" }
+        "1": { "name": "variable.parameter" }
       }
     },
-    "item-type-defn-1": {
-      "patterns": [
-        { "include": "#identifier-type" },
-        { "include": "#identifier-type-variable" }
-      ]
-    },
-    "item-type-defn-2": {
-      "begin": "=",
-      "end": "(?=\\b(and)\\b|;)",
+    "object-item": {
+      "begin": "(?:\\G|(;))[[:space:]]*",
+      "end": "[[:space:]]*(?=[;\\}])",
       "beginCaptures": {
-        "0": { "name": "keyword.operator.reason" }
+        "1": { "name": "keyword.operator" }
+      },
+      "endCaptures": {
+        "1": { "name": "keyword.operator" }
       },
       "patterns": [
-        { "include": "#type-items" },
-        { "include": "#comment" }
+        { "include": "#class-item-method" }
       ]
     },
-    "literal": {
+    "operator": {
       "patterns": [
-        { "include": "#literal-boolean" },
-        { "include": "#literal-numeric" },
-        { "include": "#literal-string" },
-        { "include": "#literal-unit" }
+        { "include": "#operator-infix" },
+        { "include": "#operator-prefix" }
       ]
     },
-    "literal-boolean": {
+    "operator-infix-builtin": {
+      "name": "keyword.operator",
+      "match": ":="
+    },
+    "operator-infix": {
+      "patterns": [
+        { "include": "#operator-infix-builtin" },
+        { "include": "#operator-infix-custom" },
+        { "include": "#operator-infix-custom-hash" }
+      ]
+    },
+    "operator-infix-custom": {
+      "name": "keyword.operator",
+      "match": "[\\-@*/&%^+<=>$][\\-:!?.@*/&%^+<=>|~$\\\\]*"
+    },
+    "operator-infix-custom-hash": {
+      "name": "keyword.operator",
+      "match": "#[\\-:!?.@*/&%^+<=>|~$]+"
+    },
+    "operator-prefix": {
+      "patterns": [
+        { "include": "#operator-prefix-bang" },
+        { "include": "#operator-prefix-label-token" }
+      ]
+    },
+    "operator-prefix-bang": {
+      "name": "keyword.operator",
+      "match": "![\\-:!?.@*/&%^+<=>|~$]*"
+    },
+    "operator-prefix-label-token": {
+      "name": "keyword.operator",
+      "match": "[?~][\\-:!?.@*/&%^+<=>|~$]+"
+    },
+    "type-expression": {
+      "comments": "FIXME: higher-rank, objects, poly-variants, etc.",
+      "patterns": [
+        { "include": "#attribute" },
+        { "include": "#comment" },
+        { "include": "#module-expression-path" },
+        { "include": "#type-expression-arrow" },
+        { "include": "#type-expression-constructor" },
+        { "include": "#type-expression-label" },
+        { "include": "#type-expression-object" },
+        { "include": "#type-expression-parens" },
+        { "include": "#type-expression-record" },
+        { "include": "#type-expression-variable" }
+      ]
+    },
+    "type-expression-arrow": {
+      "name": "keyword.operator",
+      "match": "=>"
+    },
+    "type-expression-constructor": {
+      "match": "(_)(?![A-Za-z0-9])|\\b([_a-z][A-Za-z0-9_']*)\\b(?!\\.[A-Z])",
+      "captures": {
+        "1": { "name": "variable.parameter" },
+        "2": { "name": "support.type" }
+      }
+    },
+    "type-expression-label": {
+      "begin": "[[:space:]]*\\b([_a-z][_'A-Za-z0-9]*)\\b(::)",
+      "end": "(?<=[[:space:]])",
+      "beginCaptures": {
+        "1": { "name": "constant.language" },
+        "2": { "name": "keyword.other" }
+      },
+      "patterns": [
+        { "include": "#type-expression" },
+        {
+          "match": "(\\?)",
+          "captures": {
+            "1": { "name": "keyword.other" }
+          }
+        }
+      ]
+    },
+    "type-expression-object": {
+      "begin": "(<)",
+      "end": "(>)",
+      "beginCaptures": {
+        "1": { "name": "entity.name.function" }
+      },
+      "endCaptures": {
+        "1": { "name": "entity.name.function" }
+      },
+      "patterns": [
+        {
+          "begin": "(?=[_a-z])",
+          "end": "(,)|(?=>)",
+          "endCaptures": {
+            "1": { "name": "keyword.other" }
+          },
+          "patterns": [
+            {
+              "begin": "(?=[_a-z])",
+              "end": "(?=:)",
+              "patterns": [
+                {
+                  "match": "\\b([_a-z][_'A-Za-z0-9]*)\\b",
+                  "captures": {
+                    "1": { "name": "constant.language" }
+                  }
+                }
+              ]
+            },
+            {
+              "begin": "(:)",
+              "end": "(?=[,>])",
+              "beginCaptures": {
+                "1": { "name": "keyword.other" }
+              },
+              "patterns": [
+                { "include": "#type-expression" }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "type-expression-parens": {
+      "begin": "\\(",
+      "end": "\\)",
+      "patterns": [
+        { "include": "#type-expression" }
+      ]
+    },
+    "type-expression-record": {
+      "begin": "\\{",
+      "end": "\\}",
+      "patterns": [
+        { "include": "#type-expression-record-item" }
+      ]
+    },
+    "type-expression-record-field": {
+      "comment": "FIXME: proper chaining with mutable, …",
+      "begin": "(\\bmutable\\b)?[[:space:]]*\\b([_a-z][A-Za-z0-9_']*)[[:space:]]*(?=[:\\}]|$)",
+      "end": "(?:(,)|(?=\\}))",
+      "beginCaptures": {
+        "1": { "name": "keyword.other" },
+        "2": { "name": "constant.language.field.reason" }
+      },
+      "endCaptures": {
+        "1": { "name": "keyword.operator.reason" }
+      },
+      "patterns": [
+        {
+          "begin": "\\G(:)",
+          "end": "(?=[,\\}])",
+          "beginCaptures": {
+            "1": { "name": "keyword.operator.reason" }
+          },
+          "patterns": [
+            { "include": "#type-expression" }
+          ]
+        }
+      ]
+    },
+    "type-expression-record-item": {
+      "patterns": [
+        { "include": "#module-expression-path" },
+        { "include": "#type-expression-record-field" }
+      ]
+    },
+    "type-expression-variable": {
+      "match": "'([_a-z][A-Za-z0-9_']*)\\b(?!\\.[A-Z])",
+      "captures": {
+        "1": { "name": "parameter.variable" }
+      }
+    },
+    "value-expression": {
+      "patterns": [
+        { "include": "#attribute" },
+        { "include": "#comment" },
+        { "include": "#extension-node" },
+        { "include": "#module-expression-path" },
+        { "include": "#operator" },
+        { "include": "#value-expression-builtin" },
+        { "include": "#value-expression-atomic" }
+      ]
+    },
+    "value-expression-atomic": {
+      "patterns": [
+        { "include": "#value-expression-literal" },
+        { "include": "#value-expression-literal-list" },
+        { "include": "#value-expression-if-then-else" },
+        { "include": "#value-expression-for" },
+        { "include": "#value-expression-fun" },
+        { "include": "#value-expression-block-or-record-or-object" },
+        { "include": "#value-expression-label" },
+        { "include": "#value-expression-parens" },
+        { "include": "#value-expression-switch" },
+        { "include": "#value-expression-try" },
+        { "include": "#value-expression-while" }
+      ]
+    },
+    "value-expression-block": {
+      "begin": "\\{",
+      "end": "(?=\\})",
+      "patterns": [
+        { "include": "#value-expression-block-item" }
+      ]
+    },
+    "value-expression-block-item": {
+      "begin": "(?:\\G|^|(;))[[:space:]]*",
+      "end": "[[:space:]]*(?=[;\\}\\|])",
+      "beginCaptures": {
+        "1": { "name": "keyword.operator" }
+      },
+      "endCaptures": {
+        "1": { "name": "keyword.operator" }
+      },
+      "patterns": [
+        { "include": "#module-item-let" },
+        { "include": "#module-item-open" },
+        { "include": "#value-expression" }
+      ]
+    },
+    "value-expression-block-or-record": {
+      "begin": "\\{",
+      "end": "\\}",
+      "patterns": [
+        { "include": "#comment" },
+        { "include": "#module-expression-path" },
+        { "include": "#value-expression-block-look" },
+        { "include": "#value-expression-record-item" }
+      ]
+    },
+    "value-expression-block-or-record-or-object": {
+      "begin": "\\{",
+      "end": "\\}",
+      "patterns": [
+        { "include": "#comment" },
+        { "include": "#module-expression-path" },
+        { "include": "#value-expression-object-look" },
+        { "include": "#value-expression-block-look" },
+        { "include": "#value-expression-record-item" }
+      ]
+    },
+    "value-expression-builtin": {
+      "name": "keyword.operator",
+      "match": "\\b(assert|decr|failwith|fprintf|incr|lazy|lor|lsl|lsr|lxor|mod|new|not|printf|ref)\\b"
+    },
+    "value-expression-block-look": {
+      "comment": "FIXME: is there a better way than listing all the keywords?",
+      "begin": "(?:\\G|^)[[:space:]]*(?=['\"\\(0-9]|\\b(assert|failwith|for|fun|include|if|lazy|let|new|open|switch|try|while)\\b|\\b[_a-z][A-Za-z0-9_']*\\b[[:space:]]*[^[:space:],:\\}])",
+      "end": "(?=\\})",
+      "patterns": [
+        { "include": "#value-expression-block-item" }
+      ]
+    },
+    "value-expression-for": {
+      "begin": "(?=\\bfor\\b)",
+      "end": "\\}",
+      "patterns": [
+        { "include": "#value-expression-for-head" },
+        { "include": "#value-expression-block" }
+      ]
+    },
+    "value-expression-for-head": {
+      "begin": "\\b(for)\\b",
+      "end": "(?=\\{)",
+      "beginCaptures": {
+        "1": { "name": "keyword.control.reason" }
+      },
+      "patterns": [
+        {
+          "comment": "FIXME: proper chaining",
+          "match": "\\b(in|downto|to)\\b",
+          "name": "keyword.control"
+        },
+        {
+          "comment": "FIXME: parens; anchor",
+          "include": "#value-expression"
+        }
+      ]
+    },
+    "value-expression-fun": {
+      "begin": "\\b(fun)\\b",
+      "end": "(?=[;\\)\\}])",
+      "beginCaptures": {
+        "1": { "name": "keyword.operator.reason" }
+      },
+      "patterns": [
+        { "include": "#value-expression-fun-pattern-match-rule" }
+      ]
+    },
+    "value-expression-fun-pattern-match-rule": {
+      "begin": "(?:\\G|^)[[:space:]]|(\\|)",
+      "end": "(?=[;\\)\\}|])",
+      "beginCaptures": {
+        "1": { "name": "keyword.operator.reason" }
+      },
+      "patterns": [
+        { "include": "#value-expression-fun-pattern-match-rule-lhs" },
+        { "include": "#value-expression-fun-pattern-match-rule-rhs" }
+      ]
+    },
+    "value-expression-fun-pattern-match-rule-lhs": {
+      "begin": "(?<=\\|)",
+      "end": "(?==>)",
+      "patterns": [
+        { "include": "#pattern-guard" },
+        { "include": "#pattern" }
+      ]
+    },
+    "value-expression-fun-pattern-match-rule-rhs": {
+      "begin": "(=>)",
+      "end": "(?=[\\|\\)\\};])",
+      "beginCaptures": {
+        "1": { "name": "keyword.operator.reason" }
+      },
+      "patterns": [
+        { "include": "#value-expression" }
+      ]
+    },
+    "value-expression-if-then-else": {
+      "begin": "(?=\\bif\\b)",
+      "end": "(?<=\\})",
+      "patterns": [
+        { "include": "#value-expression-if-then" },
+        { "include": "#value-expression-if-else" }
+      ]
+    },
+    "value-expression-if-then": {
+      "begin": "(?=\\bif\\b)",
+      "end": "(?=\\belse\\b|;)",
+      "endCaptures": {
+        "1": { "name": "keyword.other" }
+      },
+      "patterns": [
+        { "include": "#value-expression-if-head" },
+        { "include": "#value-expression-block" }
+      ]
+    },
+    "value-expression-if-head": {
+      "begin": "\\b(if)\\b",
+      "end": "(?=\\{)",
+      "beginCaptures": {
+        "1": { "name": "keyword.control.reason" }
+      },
+      "patterns": [
+        { "include": "#value-expression-parens" }
+      ]
+    },
+    "value-expression-if-else": {
+      "begin": "\\b(else)\\b",
+      "end": "(?=\\})",
+      "beginCaptures": {
+        "1": { "name": "keyword.control.reason" }
+      },
+      "patterns": [
+        { "include": "#value-expression-if-then-else" },
+        { "include": "#value-expression-block" }
+      ]
+    },
+    "value-expression-label": {
+      "begin": "[[:space:]]*\\b([_a-z][_'A-Za-z0-9]*)\\b(::)(\\?)?",
+      "end": "(?![[:space:]])",
+      "beginCaptures": {
+        "1": { "name": "constant.language" },
+        "2": { "name": "keyword.other" },
+        "3": { "name": "storage.type" }
+      },
+      "patterns": [
+        { "include": "#value-expression" }
+      ]
+    },
+    "value-expression-literal": {
+      "patterns": [
+        { "include": "#value-expression-literal-boolean" },
+        { "include": "#value-expression-literal-char" },
+        { "include": "#value-expression-literal-numeric" },
+        { "include": "#value-expression-literal-string" },
+        { "include": "#value-expression-literal-constructor-variant" },
+        { "include": "#value-expression-literal-constructor-variant-polymorphic" }
+      ]
+    },
+    "value-expression-literal-boolean": {
       "name": "constant.language.boolean.reason",
       "match": "\\b(false|true)\\b"
     },
-    "literal-numeric": {
-      "name": "constant.numeric.reason",
+    "value-expression-literal-char": {
+			"name": "constant.character",
+			"begin": "'",
+			"end": "'|(?:[^\\\\\\n]$)"
+    },
+    "value-expression-literal-constructor-variant": {
+      "match": "\\b([A-Z][A-Za-z0-9_']*)\\b(?!\\.)",
+      "captures": {
+        "1": { "name": "constant.language.reason" }
+      }
+    },
+    "value-expression-literal-constructor-variant-polymorphic": {
+      "match": "(`)([A-Z][A-Za-z0-9_']*)\\b(?!\\.)",
+      "captures": {
+        "1": { "name": "variable.parameter" },
+        "2": { "name": "constant.language.reason" }
+      }
+    },
+    "value-expression-literal-list": {
+      "begin": "(\\[)(?![@%])",
+      "end": "(\\])",
+      "beginCaptures": {
+        "1": { "name": "constant.language.list.reason" }
+      },
+      "endCaptures": {
+        "1": { "name": "constant.language.list.reason" }
+      },
+      "patterns": [
+        { "include": "#value-expression-literal-list-seperator" },
+        { "include": "#value-expression-literal" },
+        { "include": "#value-expression-literal-list" }
+      ]
+    },
+    "value-expression-literal-list-seperator": {
+      "match": "(,)|(\\.\\.\\.)",
+      "captures": {
+        "1": { "name": "keyword.operator" },
+        "2": { "name": "constant.language" }
+      }
+    },
+    "value-expression-literal-numeric": {
+      "name": "constant.language.numeric.reason",
       "match": "\\b(?<=[^$])((0(x|X)[0-9a-fA-F]+)|(0(o|O)[0-7]+)|(0(b|B)(0|1)+)|(([0-9]+(\\.[0-9]+)?))([eE]([+-]?)[0-9]+(\\.[0-9]+)?)?)\\b"
     },
-    "literal-string": {
+    "value-expression-literal-string": {
+			"name": "string.double.reason",
 			"begin": "\"",
 			"end": "\"|(?:[^\\\\\\n]$)",
-			"name": "string.double.reason"
+      "patterns": [
+        {
+          "match": "(@)([ \\[\\],.]|\\\\n)",
+          "captures": {
+            "1": { "name": "keyword.operator" },
+            "2": { "name": "constant.language" }
+          }
+        },
+        {
+          "match": "(%)([ads])?",
+          "captures": {
+            "1": { "name": "keyword.operator" },
+            "2": { "name": "variable.parameter" }
+          }
+        }
+      ]
     },
-    "literal-unit": {
+    "value-expression-literal-unit": {
       "name": "constant.language.unit.reason",
       "match": "\\(\\)"
     },
-    "module-items": {
+    "value-expression-object-look": {
+      "comment": "FIXME: is there a better way than listing all the keywords?",
+      "begin": "(?:\\G|^)[[:space:]]*(?=\\b(method)\\b)",
+      "end": "(?=\\})",
       "patterns": [
-        { "include": "#item-include" },
-        { "include": "#item-let-defn" },
-        { "include": "#item-module-type-defn" },
-        { "include": "#item-open" },
-        { "include": "#item-type-defn" },
-        { "include": "#comment" }
+        { "include": "#object-item" }
       ]
     },
-    "module-type-items": {
+    "value-expression-parens": {
+      "begin": "(?=\\()",
+      "end": "\\)",
       "patterns": [
-        { "include": "#item-include" },
-        { "include": "#item-let-decl" },
-        { "include": "#item-open" },
-        { "include": "#item-type-defn" },
-        { "include": "#comment" }
+        { "include": "#value-expression-parens-lhs" }
       ]
     },
-    "type-items": {
-      "begin": "\\G|\\|",
-      "end": "(?=\\b(and)\\b|;|\\|)",
+    "value-expression-parens-lhs": {
+      "begin": "(?:\\(|(,))",
+      "end": "(?=(?:[,:\\)]|\\bas\\b))",
       "beginCaptures": {
-        "0": { "name": "keyword.other.reason" }
+        "1": { "name": "keyword.operator" }
+      },
+      "patterns": [
+        { "include": "#value-expression" }
+      ]
+    },
+    "value-expression-record": {
+      "begin": "\\{",
+      "end": "\\}",
+      "patterns": [
+        { "include": "#value-expression-record-item" }
+      ]
+    },
+    "value-expression-record-field": {
+      "begin": "(\\.\\.\\.)?\\b([_a-z][A-Za-z0-9_']*)[[:space:]]*(?=[,:\\}]|$)",
+      "end": "(?:(,)|(?=\\}))",
+      "beginCaptures": {
+        "1": { "name": "keyword.other" },
+        "2": { "name": "constant.language.field.reason" }
+      },
+      "endCaptures": {
+        "1": { "name": "keyword.operator.reason" }
       },
       "patterns": [
         {
-          "comment": "FIXME",
-          "name": "keyword.other.type.reason",
-          "match": "\\bof\\b"
-        },
+          "begin": "\\G(:)",
+          "end": "(?=[,\\}])",
+          "beginCaptures": {
+            "1": { "name": "keyword.operator.reason" }
+          },
+          "patterns": [
+            { "include": "#value-expression" }
+          ]
+        }
+      ]
+    },
+    "value-expression-record-item": {
+      "patterns": [
+        { "include": "#module-expression-path" },
+        { "include": "#value-expression-record-field" }
+      ]
+    },
+    "value-expression-switch": {
+      "begin": "(?=\\bswitch\\b)",
+      "end": "\\}",
+      "patterns": [
+        { "include": "#value-expression-switch-head" },
+        { "include": "#value-expression-switch-body" }
+      ]
+    },
+    "value-expression-switch-head": {
+      "begin": "\\b(switch)\\b",
+      "end": "(?=\\{)",
+      "beginCaptures": {
+        "1": { "name": "keyword.control.reason" }
+      },
+      "patterns": [
         {
-          "match": "\\[\\]|::",
-          "captures": {
-            "0" : { "name": "constant.language.constructor.reason" }
-          }
-        },
-        { "include": "#identifier-constructor" },
-        { "include": "#identifier-module" },
-        { "include": "#identifier-type" },
-        { "include": "#identifier-type-variable" },
-        { "include": "#comment" }
+          "comment": "FIXME: parens; anchor",
+          "include": "#value-expression"
+        }
+      ]
+    },
+    "value-expression-switch-body": {
+      "begin": "\\{",
+      "end": "(?=\\})",
+      "patterns": [
+        { "include": "#comment" },
+        { "include": "#value-expression-switch-pattern-match-rule" }
+      ]
+    },
+    "value-expression-switch-pattern-match-rule": {
+      "patterns": [
+        { "include": "#value-expression-switch-pattern-match-rule-lhs" },
+        { "include": "#value-expression-switch-pattern-match-rule-rhs" }
+      ]
+    },
+    "value-expression-switch-pattern-match-rule-lhs": {
+      "begin": "(\\|)",
+      "end": "(?==>)",
+      "beginCaptures": {
+        "1": { "name": "keyword.operator.reason" }
+      },
+      "patterns": [
+        { "include": "#pattern-guard" },
+        { "include": "#pattern" }
+      ]
+    },
+    "value-expression-switch-pattern-match-rule-rhs": {
+      "begin": "(=>)",
+      "end": "(?=[\\|\\}])",
+      "beginCaptures": {
+        "1": { "name": "keyword.operator.reason" }
+      },
+      "patterns": [
+        { "include": "#value-expression-block-item" }
+      ]
+    },
+    "value-expression-try": {
+      "begin": "(?=\\btry\\b)",
+      "end": "\\}",
+      "patterns": [
+        { "include": "#value-expression-try-head" },
+        { "include": "#value-expression-try-body" }
+      ]
+    },
+    "value-expression-try-head": {
+      "begin": "\\b(try)\\b",
+      "end": "(?=\\{)",
+      "beginCaptures": {
+        "1": { "name": "keyword.control.reason" }
+      }
+    },
+    "value-expression-try-body": {
+      "begin": "\\{",
+      "end": "(?=\\})",
+      "patterns": [
+        { "include": "#comment" },
+        { "include": "#value-expression-switch-pattern-match-rule" }
+      ]
+    },
+    "value-expression-while": {
+      "begin": "(?=\\bwhile\\b)",
+      "end": "\\}",
+      "patterns": [
+        { "include": "#value-expression-while-head" },
+        { "include": "#value-expression-block" }
+      ]
+    },
+    "value-expression-while-head": {
+      "begin": "\\b(while)\\b",
+      "end": "(?=\\{)",
+      "beginCaptures": {
+        "1": { "name": "keyword.control.reason" }
+      },
+      "patterns": [
+        {
+          "comment": "FIXME: parens; anchor",
+          "include": "#value-expression"
+        }
       ]
     }
   }

--- a/syntaxes/reason-hover.json
+++ b/syntaxes/reason-hover.json
@@ -1,31 +1,5 @@
 {
   "scopeName": "source.reason.hover",
   "patterns": [
-    {
-      "begin": "{",
-      "end": "}",
-      "patterns": [
-        { "include": "source.reason.module.type" }
-      ]
-    },
-    {
-      "begin": "\\b(type)\\b",
-      "end": "$",
-      "beginCaptures": {
-        "1": { "name": "keyword.other.type.reason" }
-      },
-      "endCaptures": {
-        "0": { "name": "keyword.operator.reason" }
-      },
-      "patterns": [
-        { "include": "source.reason.common#bind-item-type" }
-      ]
-    },
-    { "include": "source.reason.common#identifier-type" },
-    { "include": "source.reason.common#identifier-type-variable" },
-    {
-      "name": "keyword.operator.reason",
-      "match": "=>"
-    }
   ]
 }

--- a/syntaxes/reason-module-decls.json
+++ b/syntaxes/reason-module-decls.json
@@ -1,0 +1,9 @@
+{
+  "scopeName": "source.reason.module.decls",
+  "fileTypes": [
+    "rei"
+  ],
+  "patterns": [
+    { "include": "source.reason.common#module-expression-block-item" }
+  ]
+}

--- a/syntaxes/reason-module-defns.json
+++ b/syntaxes/reason-module-defns.json
@@ -1,0 +1,9 @@
+{
+  "scopeName": "source.reason.module.defns",
+  "fileTypes": [
+    "re"
+  ],
+  "patterns": [
+    { "include": "source.reason.common#module-expression-block-item" }
+  ]
+}

--- a/syntaxes/reason-module-type.json
+++ b/syntaxes/reason-module-type.json
@@ -1,9 +1,0 @@
-{
-  "scopeName": "source.reason.module.type",
-  "fileTypes": [
-    "rei"
-  ],
-  "patterns": [
-    { "include": "source.reason.common#module-type-items" }
-  ]
-}

--- a/syntaxes/reason-module.json
+++ b/syntaxes/reason-module.json
@@ -1,9 +1,0 @@
-{
-  "scopeName": "source.reason.module",
-  "fileTypes": [
-    "re"
-  ],
-  "patterns": [
-    { "include": "source.reason.common#module-items" }
-  ]
-}


### PR DESCRIPTION
Remaining tasks:

* class type expressions
  - [ ] type parameters
* module expressions
  - [ ] computed signatures
  - [ ] constraints
  - [ ] functor parameters
  - [ ] `val` (unpack)
  - [ ] substitutions
* object expressions
  - [ ] `inherit`
  - [ ] `private`
* pattern expressions
  - [x] `lazy`
  - [x] `when`
* term expressions
  - [ ] array update
  - [ ] coercions
  - [x] labeled arguments
  - [x] `for` loops
  - [ ] `if` without needing enclosing `{` and `}` for atomic expressions
  - [x] `let` with pattern matching
  - [x] `switch` branches with items without needing enclosing `{` and `}`
  - [ ] record projections (highlight as constants)
* type expressions
  - [ ] constraints
  - [ ] extensible variant type
  - [ ] higher rank type
  - [x] labeled type
  - [ ] locally abstract type
  - [x] object type
  - [ ] polymorphic variant type
  - [x] `mutable`
  - [x] `private`
  - [x] records
  - [ ] subtyping
  - [x] variance annotations

