### PR TITLE
Add reason.codelens.enabled setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,11 @@
           "default": true,
           "description": "Enable the use of unicode symbols in codelens."
         },
+        "reason.codelens.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Specifies whether the code lens is shown."
+        },
         "reason.debounce.linter": {
           "type": "integer",
           "default": 500,


### PR DESCRIPTION
As discussed in https://github.com/freebroccolo/vscode-reasonml/issues/70

I followed the `.enabled` convention from gitlens and typescript extensions as a suffix for the setting.

Related to https://github.com/freebroccolo/ocaml-language-server/pull/11