### PR TITLE
allow imandra as a language in reason.server.languages

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,24 @@
   "engines": {
     "vscode": "^1.21.0"
   },
-  "categories": ["Formatters", "Programming Languages", "Linters", "Snippets"],
-  "keywords": ["ocaml", "reason", "bucklescript", "reasonml", "merlin"],
+  "categories": [
+    "Formatters",
+    "Programming Languages",
+    "Linters",
+    "Snippets"
+  ],
+  "keywords": [
+    "ocaml",
+    "reason",
+    "bucklescript",
+    "reasonml",
+    "merlin"
+  ],
   "icon": "assets/logo.png",
-  "activationEvents": ["onLanguage:ocaml", "onLanguage:reason"],
+  "activationEvents": [
+    "onLanguage:ocaml",
+    "onLanguage:reason"
+  ],
   "main": "./out/src/extension",
   "contributes": {
     "commands": [
@@ -60,26 +74,34 @@
               "type": "integer"
             },
             {
-              "enum": ["Infinity"]
+              "enum": [
+                "Infinity"
+              ]
             }
           ],
           "default": 500,
-          "description":
-            "How long to idle (in milliseconds) after keypresses before refreshing linter diagnostics. Smaller values refresh diagnostics more quickly."
+          "description": "How long to idle (in milliseconds) after keypresses before refreshing linter diagnostics. Smaller values refresh diagnostics more quickly."
         },
         "reason.diagnostics.tools": {
           "type": "array",
           "items": {
-            "enum": ["merlin", "bsb"]
+            "enum": [
+              "merlin",
+              "bsb"
+            ]
           },
-          "default": ["merlin"],
+          "default": [
+            "merlin"
+          ],
           "maxItems": 2,
           "uniqueItems": true,
-          "description":
-            "Specifies which tool or tools will be used to get diagnostics. If you choose both \"merlin\" and \"bsb\", merlin will be used while editing and bsb when saving."
+          "description": "Specifies which tool or tools will be used to get diagnostics. If you choose both \"merlin\" and \"bsb\", merlin will be used while editing and bsb when saving."
         },
         "reason.format.width": {
-          "type": ["number", null],
+          "type": [
+            "number",
+            null
+          ],
           "default": null,
           "description": "Set the width of lines when formatting code with refmt"
         },
@@ -101,8 +123,7 @@
         "reason.path.env": {
           "type": "string",
           "default": "env",
-          "description":
-            "The path to the `env` command which prints the language server environment for debugging editor issues."
+          "description": "The path to the `env` command which prints the language server environment for debugging editor issues."
         },
         "reason.path.ocamlmerlin": {
           "type": "string",
@@ -142,12 +163,26 @@
         "reason.server.languages": {
           "type": "array",
           "items": {
-            "enum": ["ocaml", "reason", "imandra"]
+            "enum": [
+              "ocaml",
+              "reason",
+              "imandra",
+              "imandra-reason"
+            ]
           },
-          "default": ["ocaml", "reason"],
-          "maxItems": 3,
+          "default": [
+            "ocaml",
+            "reason"
+          ],
+          "maxItems": 4,
           "uniqueItems": true,
           "description": "The list of languages enable support for in the language server."
+        },
+        "reason.path.ocamlmerlinArgs": {
+          "type": "array",
+          "uniqueItems": true,
+          "default": [],
+          "description": "Merlin flags and arguments to be passed"
         }
       }
     },
@@ -205,7 +240,9 @@
       {
         "scopeName": "markdown.reason.codeblock",
         "path": "./syntaxes/reason-markdown-codeblock.json",
-        "injectTo": ["text.html.markdown"],
+        "injectTo": [
+          "text.html.markdown"
+        ],
         "embeddedLanguages": {
           "meta.embedded.block.reason": "reason"
         }
@@ -213,7 +250,9 @@
       {
         "scopeName": "markdown.ocaml.codeblock",
         "path": "./syntaxes/ocaml-markdown-codeblock.json",
-        "injectTo": ["text.html.markdown"],
+        "injectTo": [
+          "text.html.markdown"
+        ],
         "embeddedLanguages": {
           "meta.embedded.block.ocaml": "ocaml"
         }
@@ -222,8 +261,13 @@
     "languages": [
       {
         "id": "ocaml",
-        "aliases": ["OCaml"],
-        "extensions": [".ml", ".mli"],
+        "aliases": [
+          "OCaml"
+        ],
+        "extensions": [
+          ".ml",
+          ".mli"
+        ],
         "configuration": "./ocaml.configuration.json"
       },
       {
@@ -234,23 +278,40 @@
       },
       {
         "id": "ocaml.merlin",
-        "aliases": ["Merlin"],
-        "extensions": ["merlin"]
+        "aliases": [
+          "Merlin"
+        ],
+        "extensions": [
+          "merlin"
+        ]
       },
       {
         "id": "ocaml.ocamlbuild",
-        "aliases": ["OCamlbuild"],
-        "extensions": ["_tags"]
+        "aliases": [
+          "OCamlbuild"
+        ],
+        "extensions": [
+          "_tags"
+        ]
       },
       {
         "id": "ocaml.opam",
-        "aliases": ["OPAM"],
-        "extensions": ["opam"]
+        "aliases": [
+          "OPAM"
+        ],
+        "extensions": [
+          "opam"
+        ]
       },
       {
         "id": "reason",
-        "aliases": ["Reason"],
-        "extensions": [".re", ".rei"],
+        "aliases": [
+          "Reason"
+        ],
+        "extensions": [
+          ".re",
+          ".rei"
+        ],
         "configuration": "./reason.configuration.json"
       },
       {
@@ -281,20 +342,20 @@
     "problemMatchers": [
       {
         "name": "ocamlc",
-
-        "fileLocation": ["relative", "${workspaceFolder}"],
+        "fileLocation": [
+          "relative",
+          "${workspaceFolder}"
+        ],
         "pattern": [
           {
-            "regexp":
-              "^\\s*\\bFile\\b\\s*\"(.*)\",\\s*\\bline\\b\\s*(\\d+),\\s*\\bcharacters\\b\\s*(\\d+)-(\\d+)\\s*:\\s*$",
+            "regexp": "^\\s*\\bFile\\b\\s*\"(.*)\",\\s*\\bline\\b\\s*(\\d+),\\s*\\bcharacters\\b\\s*(\\d+)-(\\d+)\\s*:\\s*$",
             "file": 1,
             "line": 2,
             "column": 3,
             "endColumn": 4
           },
           {
-            "regexp":
-              "^(?:\\s*\\bParse\\b\\s*)?\\s*\\b([Ee]rror|Warning)\\b\\s*(?:\\(\\s*\\bwarning\\b\\s*(\\d+)\\))?\\s*:\\s*(.*)$",
+            "regexp": "^(?:\\s*\\bParse\\b\\s*)?\\s*\\b([Ee]rror|Warning)\\b\\s*(?:\\(\\s*\\bwarning\\b\\s*(\\d+)\\))?\\s*:\\s*(.*)$",
             "severity": 1,
             "code": 2,
             "message": 3
@@ -322,7 +383,7 @@
   },
   "dependencies": {
     "lodash.flatmap": "^4.5.0",
-    "ocaml-language-server": "1.0.35",
+    "ocaml-language-server": "file:../ocaml-language-server",
     "pegjs": "0.10.0",
     "vscode-jsonrpc": "3.6.0",
     "vscode-languageclient": "4.0.1",

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -40,7 +40,7 @@ export async function launch(context: vscode.ExtensionContext): Promise<void> {
     transport,
   };
   const serverOptions = { run, debug };
-  const languages = reasonConfig.get<string[]>("server.languages", ["ocaml", "reason"]);
+  const languages = reasonConfig.get<string[]>("server.languages", ["ocaml", "reason", "imandra"]);
   const documentSelector = flatMap(languages, (language: string) => [
     { language, scheme: "file" },
     { language, scheme: "untitled" },
@@ -58,6 +58,8 @@ export async function launch(context: vscode.ExtensionContext): Promise<void> {
       fileEvents: [
         vscode.workspace.createFileSystemWatcher("**/.merlin"),
         vscode.workspace.createFileSystemWatcher("**/*.ml"),
+        vscode.workspace.createFileSystemWatcher("**/*.iml"),
+        vscode.workspace.createFileSystemWatcher("**/*.ire"),
         vscode.workspace.createFileSystemWatcher("**/*.re"),
         vscode.workspace.createFileSystemWatcher("**/command-exec"),
         vscode.workspace.createFileSystemWatcher("**/command-exec.bat"),


### PR DESCRIPTION
This PR is to ask for the `imandra` and `imanda-reason` languages to be included in the list of allowable languages for the plugin. I mentioned it first on the discord editor-support channel. I will set out why and how this would be great here. I'd be very grateful if you could have a look and let me know whether you think this is acceptable.

-- we have developed the imandra reasoning engine which analyses ocaml and reason files, and is a subset of the ocaml language itself. You can try it live by looking at the docs here: 

https://docs.imandra.ai/imandra-docs/

-- we have also developed a merlin reader for imandra extension of ocaml and reason

-- your VSCode plugin works brilliantly if we activate it for `imandra` or `imandra reason` files and change the executable for merlin to be a script we provide which calls merlin with the imandra reader. We have developed a plugin of our own which adds yours as a "installation dependency" - that is we add this line to the `package.json`:

```
"extensionDependencies": [
    "freebroccolo.reasonml"
  ]
```
This is our repo:

https://github.com/AestheticIntegration/imandra-vscode/

what is done in our extension on activate is to redefine the environment variables in the workspace to:
```
{
    "reason.server.languages": [
        "ocaml",
        "reason",
        "imandra",
        "imandra-reason"
    ],
    "reason.path.ocamlmerlin": "~/.vscode/extensions/aestheticintegration.iml-vscode-0.1.1/ext-script/imandra-merlin"
}
```
for example. This then works fine - I execute the reload window command if the value of the `reason.path.ocamlmerlin` has changed then it reactivates your plugin with these settings.

The reason for the PR is that we get warnings because "imandra"  and "imandra-reason" are not permissible languages, and because the max allowable length of the array is 2.  I have changed the `package.json` so that "imandra" is permissible and so that the length of the array can be 4. There maybe a more principled way of allowing the array to be extended in a workspace without the warning of course.

--
Future potential related work:

I have a fork of merlin which accepts command line arguments allowing a user to specify a reader for a file suffix. I would like to add this as an environment variable here at some point so that we can choose how merlin analyses different files in a workspace - currently it is workspace global for imandra. 

--
VSCode note - I am trying to work out how to change the activation order of plugins - if I could write these settings using ours first then activate yours that would be best, but the activation order is always that the installation dependency activates first - I am trying to change this. 
